### PR TITLE
Get rid of logging-in padding

### DIFF
--- a/login_buttons.html
+++ b/login_buttons.html
@@ -7,21 +7,9 @@
 
 <template name="_loginButtons">
 	{{#if currentUser}}
-		{{#if loggingIn}}
-			{{! We aren't actually logged in yet; we're just setting Meteor.userId
-					optimistically during an at-startup login-with-token. We expose this
-					state so other UIs can treat it specially, but we'll just treat it
-					as logged out. }}
-			{{#if dropdown}}
-				{{> _loginButtonsLoggingIn }}
-			{{else}}
-				<div class="login-buttons-with-only-one-button">
-					{{> _loginButtonsLoggingInSingleLoginButton }}
-				</div>
-			{{/if}}
-		{{else}}
+		{{#unless loggingIn}}
 			{{> _loginButtonsLoggedIn}}
-		{{/if}}
+		{{/unless}}
 	{{else}}
 		{{> _loginButtonsLoggedOut}}
 	{{/if}}
@@ -42,11 +30,9 @@
 				{{> _loginButtonsLoggedOutDropdown}}
 			{{else}}
 				{{#with singleService}} {{! at this point there must be only one configured services }}
-						{{#if loggingIn}}
-							{{> _loginButtonsLoggingInSingleLoginButton}}
-						{{else}}
-							{{> _loginButtonsLoggedOutSingleLoginButton}}
-						{{/if}}
+					{{#unless logginIn}}
+						{{> _loginButtonsLoggedOutSingleLoginButton}}
+					{{/unless}}
 				{{/with}}
 			{{/if}}
 		{{/if}}
@@ -63,24 +49,4 @@
 	{{#if infoMessage}}
 		<div class="alert alert-success no-margin">{{infoMessage}}</div>
 	{{/if}}
-</template>
-
-<template name="_loginButtonsLoggingIn">
-	{{> _loginButtonsLoggingInPadding}}
-	<div class="loading">&nbsp;</div>
-	{{> _loginButtonsLoggingInPadding}}
-</template>
-
-<template name="_loginButtonsLoggingInPadding">
-	{{#unless dropdown}}
-		{{! invisible div used for correct height of surrounding div. this ensures
-				that the _loginButtons template is always the same height
-				and the rest of the page doesn't move up and down }}
-		<div class="login-buttons-padding">
-			<div class="login-button single-login-button" style="visibility: hidden;" id="login-buttons-logout">&nbsp;</div>
-		</div>
-	{{else}}
-		{{! just add some padding }}
-		<div class="login-buttons-padding"></div>
-	{{/unless}}
 </template>

--- a/login_buttons.js
+++ b/login_buttons.js
@@ -75,17 +75,6 @@
 
 
 	//
-	// loginButtonsLoggingInPadding template
-	//
-
-
-	Template._loginButtonsLoggingInPadding.helpers({
-		dropdown: function() {
-			return Accounts._loginButtons.dropdown();
-		}
-	});
-
-	//
 	// helpers
 	//
 

--- a/login_buttons_single.html
+++ b/login_buttons_single.html
@@ -9,12 +9,6 @@
 	</div>
 </template>
 
-<template name="_loginButtonsLoggingInSingleLoginButton">
-	<div class="login-text-and-button">
-		{{> _loginButtonsLoggingIn}}
-	</div>
-</template>
-
 <template name="_loginButtonsLoggedInSingleLogoutButton">
 	<li>
 		<a href="#" id="login-buttons-logout">{{displayName}} {{i18n 'loginButtonsLoggedInSingleLogoutButton.signOut'}}</a>

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-	name: 'ian:accounts-ui-bootstrap-3',
+	name: 'hpx7:accounts-ui-bootstrap-3',
 	summary: 'Bootstrap-styled accounts-ui with multi-language support.',
-	version: '1.1.23',
-	git: "https://github.com/ianmartorell/meteor-accounts-ui-bootstrap-3"
+	version: '1.1.26',
+	git: "https://github.com/hpx7/meteor-accounts-ui-bootstrap-3"
 })
 
 Package.on_use(function (api) {


### PR DESCRIPTION
Not sure what purpose this originally served, but it seems to break the ui in this package when combined with the meteorhacks:fast-render package (it increases the height of the navbar during page load). This pr removes the padding to fix this.

A more long-term solution may be to add a proper loggingIn template, rather than just the padding.
