### PR TITLE
Greek translation el.i18n.js ISO 639-1 two letter code

### DIFF
--- a/i18n/el.i18n.js
+++ b/i18n/el.i18n.js
@@ -1,0 +1,84 @@
+i18n.map("el", {
+	resetPasswordDialog: {
+		title: "Ακύρωση κωδικού",
+		newPassword: "Νέος κωδικός",
+		cancel: "Ακύρωση",
+		submit: "Ορισμός κωδικού"
+	},
+	enrollAccountDialog: {
+		title: "Επιλέξτε κωδικό",
+		newPassword: "Νέος κωδικός",
+		cancel: "Κλείσιμο",
+		submit: "Ορισμός κωδικού"
+	},
+	justVerifiedEmailDialog: {
+		verified: "Ο λογαριασμός ηλεκτρονικού ταχυδρομείου έχει επιβεβαιωθεί",
+		dismiss: "Κλείσιμο"
+	},
+	loginButtonsMessagesDialog: {
+		dismiss: "Κλείσιμο",
+	},
+	loginButtonsLoggedInDropdownActions: {
+		password: "Αλλαγή κωδικού",
+		signOut: "Αποσύνδεση"
+	},
+	loginButtonsLoggedOutDropdown: {
+		signIn: "Είσοδος",
+		up: "επάνω"
+	},
+	loginButtonsLoggedOutPasswordServiceSeparator: {
+		or: "ή"
+	},
+	loginButtonsLoggedOutPasswordService: {
+		create: "Δημιουργία",
+		signIn: "Είσοδος",
+		forgot: "Ξεχάσατε τον κωδικό σας;",
+		createAcc: "Δημιουργία κωδικού"
+	},
+	forgotPasswordForm: {
+		email: "Ηλεκτρονικό ταχυδρομείο (email)",
+		reset: "Ακύρωση κωδικού",
+		sent: "Το email έχει αποσταλεί"
+	},
+	loginButtonsBackToLoginLink: {
+		back: "Ακύρωση"
+	},
+	loginButtonsChangePassword: {
+		submit: "Αλλαγή κωδικού",
+		cancel: "Ακύρωση"
+	},
+	loginButtonsLoggedOutSingleLoginButton: {
+		signInWith: "Είσοδος με",
+		configure: "Διαμόρφωση",
+	},
+	loginButtonsLoggedInSingleLogoutButton: {
+		signOut: "Αποσύνδεση"
+	},
+	loginButtonsLoggedOut: {
+		noLoginServices: "Δεν έχουν διαμορφωθεί υπηρεσίες εισόδου"
+	},
+	loginFields: {
+		usernameOrEmail: "Όνομα χρήστη ή Λογαριασμός Ηλεκτρονικού Ταχυδρομείου",
+		username: "Όνομα χρήστη",
+		email: "Ηλεκτρονικό ταχυδρομείο (email)",
+		password: "Κωδικός"
+	},
+	signupFields: {
+		username: "Όνομα χρήστη",
+		email: "Ηλεκτρονικό ταχυδρομείο (email)",
+		emailOpt: "Ηλεκτρονικό ταχυδρομείο (προαιρετικό)",
+		password: "Κωδικός",
+		passwordAgain: "Κωδικός (ξανά)"
+	},
+	changePasswordFields: {
+		currentPassword: "Ισχύων Κωδικός",
+		newPassword: "Νέος Κωδικός",
+		newPasswordAgain: "Νέος Κωδικός (ξανά)"
+	},
+	errorMessages: {
+		usernameTooShort: "Το όνομα χρήστη πρέπει να είναι τουλάχιστον 3 χαρακτήρες",
+		invalidEmail: "Μη έγκυρος λογαριασμός ηλεκτρονικού ταχυδρομείου (email)",
+		passwordTooShort: "Ο κωδικός πρέπει να είναι τουλάχιστον 6 χαρακτήρες",
+		passwordsDontMatch: "Οι κωδικοί δεν ταιριάζουν"
+	}
+})


### PR DESCRIPTION
Added Greek translation file `el.i18n.js`.

The language code is based on  [639-1 two letter code](http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
