### PR TITLE
img-circular -> img-circle + height=width

### DIFF
--- a/login_buttons_dropdown.html
+++ b/login_buttons_dropdown.html
@@ -6,7 +6,7 @@
 		<a class="dropdown-toggle" data-toggle="dropdown">
 			{{displayName}}
 			{{#with user_profile_picture}}
-				<img src="{{this}}" width="30px" class="img-circular" alt="#" />
+				<img src="{{this}}" width="30px" height="30px" class="img-circle" alt="#" />
 			{{/with}}
 			<b class="caret"></b>
 		</a>


### PR DESCRIPTION
The correct bootstrap class for displaying images in a circular frame is `img-circle`. Also, setting `height="30px"` makes the image not look skewed in the circle. 

`img-responsive` did not produce the desired results, hence skipping that for now, but should be considered for future.