### PR TITLE
PR: adds onCreate callback

### DIFF
--- a/accounts_ui.js
+++ b/accounts_ui.js
@@ -23,7 +23,7 @@ Accounts.ui.navigate = function (route, hash) {
 
 Accounts.ui.config = function(options) {
 	// validate options keys
-	var VALID_KEYS = ['passwordSignupFields', 'extraSignupFields', 'forceEmailLowercase', 'forceUsernameLowercase','forcePasswordLowercase',
+	var VALID_KEYS = ['onCreate', 'passwordSignupFields', 'extraSignupFields', 'forceEmailLowercase', 'forceUsernameLowercase','forcePasswordLowercase',
 	'requestPermissions', 'requestOfflineToken', 'forceApprovalPrompt'];
 
 	_.each(_.keys(options), function(key) {
@@ -31,6 +31,13 @@ Accounts.ui.config = function(options) {
 			throw new Error("Accounts.ui.config: Invalid key: " + key);
 		}
 	});
+
+	if (typeof options.onCreate === 'function') {
+		Accounts.ui._options.onCreate = options.onCreate;
+	} else {
+		throw new Error("Accounts.ui.config: Value for 'onCreate' must be a" +
+				" function");
+	}
 
 	options.extraSignupFields = options.extraSignupFields || [];
 

--- a/accounts_ui.js
+++ b/accounts_ui.js
@@ -32,8 +32,10 @@ Accounts.ui.config = function(options) {
 		}
 	});
 
-	if (typeof options.onCreate === 'function') {
+	if (options.onCreate && typeof options.onCreate === 'function') {
 		Accounts.ui._options.onCreate = options.onCreate;
+	} else if (! options.onCreate ) {
+		//ignore and skip
 	} else {
 		throw new Error("Accounts.ui.config: Value for 'onCreate' must be a" +
 				" function");

--- a/login_buttons_dropdown.js
+++ b/login_buttons_dropdown.js
@@ -106,29 +106,37 @@
 			event.stopPropagation();
 			loginButtonsSession.resetMessages();
 
-			// store values of fields before swtiching to the signup form
-			var username = trimmedElementValueById('login-username');
-			var email = trimmedElementValueById('login-email');
-			var usernameOrEmail = trimmedElementValueById('login-username-or-email');
-			// notably not trimmed. a password could (?) start or end with a space
-			var password = elementValueById('login-password');
+			//check to see if onCreate is populated with a function. If it is, call it
+			var onCreateFn = Accounts.ui._options.onCreate;
+			if (onCreateFn){
+				loginButtonsSession.closeDropdown();
+				onCreateFn.apply();
 
-			loginButtonsSession.set('inSignupFlow', true);
-			loginButtonsSession.set('inForgotPasswordFlow', false);
+			} else {
+				// store values of fields before swtiching to the signup form
+				var username = trimmedElementValueById('login-username');
+				var email = trimmedElementValueById('login-email');
+				var usernameOrEmail = trimmedElementValueById('login-username-or-email');
+				// notably not trimmed. a password could (?) start or end with a space
+				var password = elementValueById('login-password');
 
-			// force the ui to update so that we have the approprate fields to fill in
-			Meteor.flush();
+				loginButtonsSession.set('inSignupFlow', true);
+				loginButtonsSession.set('inForgotPasswordFlow', false);
 
-			// update new fields with appropriate defaults
-			if (username !== null){
-				document.getElementById('login-username').value = username;
-			} else if (email !== null){
-				document.getElementById('login-email').value = email;
-			} else if (usernameOrEmail !== null){
-				if (usernameOrEmail.indexOf('@') === -1){
-					document.getElementById('login-username').value = usernameOrEmail;
-				} else {
-					document.getElementById('login-email').value = usernameOrEmail;
+				// force the ui to update so that we have the approprate fields to fill in
+				Meteor.flush();
+
+				// update new fields with appropriate defaults
+				if (username !== null) {
+					document.getElementById('login-username').value = username;
+				} else if (email !== null) {
+					document.getElementById('login-email').value = email;
+				} else if (usernameOrEmail !== null) {
+					if (usernameOrEmail.indexOf('@') === -1) {
+						document.getElementById('login-username').value = usernameOrEmail;
+					} else {
+						document.getElementById('login-email').value = usernameOrEmail;
+					}
 				}
 			}
 		},


### PR DESCRIPTION
This pull request adds onCreate to the configuration so that user creation may be overridden.  I have an app where the base signup provided was inadequate so this allows you to (optionally) call out to a separate function and show a "create user" page(s).

BTW, the diff for login_buttons_dropdown.js makes it seem more complex than it is.  There are really only 5 lines ADDED and one line of comments.  All the supposed deletions are just wrapped within an if block (see the big addition at the end).

Questions & comments welcome.