### PR TITLE
Replaced deprecated meteor stylus package with coagmano:stylus

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.on_use(function (api) {
 	api.use(['session@1.0.0',
 		'spacebars@1.0.0',
-		'stylus@1.0.0 || 2.0.0',
+		'coagmano:stylus@1.0.3',
 		'accounts-base@1.0.0',
 		'underscore@1.0.0',
 		'templating@1.0.0',


### PR DESCRIPTION
Replace meteor stylus package dependency after [deprecation in Meteor 1.6.1](https://docs.meteor.com/changelog.html#v16120180119)

See
https://github.com/ianmartorell/meteor-accounts-ui-bootstrap-3/issues/231
