### PR TITLE
Remove/update old calls to Meteor.flush()

### DIFF
--- a/login_buttons_dropdown.js
+++ b/login_buttons_dropdown.js
@@ -121,6 +121,9 @@
 				loginButtonsSession.set('inSignupFlow', true);
 				loginButtonsSession.set('inForgotPasswordFlow', false);
 
+				// force the ui to update so that we have the approprate fields to fill in
+				Tracker.flush();
+
 				// update new fields with appropriate defaults
 				if (username !== null) {
 					document.getElementById('login-username').value = username;
@@ -146,6 +149,8 @@
 			loginButtonsSession.set('inSignupFlow', false);
 			loginButtonsSession.set('inForgotPasswordFlow', true);
 
+			// force the ui to update so that we have the approprate fields to fill in
+			Tracker.flush();
 			//toggleDropdown();
 
 			// update new fields with appropriate defaults
@@ -166,6 +171,9 @@
 
 			loginButtonsSession.set('inSignupFlow', false);
 			loginButtonsSession.set('inForgotPasswordFlow', false);
+
+			// force the ui to update so that we have the approprate fields to fill in
+			Tracker.flush();
 
 			if (document.getElementById('login-username')){
 				document.getElementById('login-username').value = username;
@@ -363,6 +371,7 @@
 			event.stopPropagation();
 			loginButtonsSession.resetMessages();
 			Accounts._loginButtonsSession.set('inChangePasswordFlow', false);
+			Tracker.flush();
 		}
 	});
 

--- a/login_buttons_dropdown.js
+++ b/login_buttons_dropdown.js
@@ -121,9 +121,6 @@
 				loginButtonsSession.set('inSignupFlow', true);
 				loginButtonsSession.set('inForgotPasswordFlow', false);
 
-				// force the ui to update so that we have the approprate fields to fill in
-				Meteor.flush();
-
 				// update new fields with appropriate defaults
 				if (username !== null) {
 					document.getElementById('login-username').value = username;
@@ -149,8 +146,6 @@
 			loginButtonsSession.set('inSignupFlow', false);
 			loginButtonsSession.set('inForgotPasswordFlow', true);
 
-			// force the ui to update so that we have the approprate fields to fill in
-			Meteor.flush();
 			//toggleDropdown();
 
 			// update new fields with appropriate defaults
@@ -171,9 +166,6 @@
 
 			loginButtonsSession.set('inSignupFlow', false);
 			loginButtonsSession.set('inForgotPasswordFlow', false);
-
-			// force the ui to update so that we have the approprate fields to fill in
-			Meteor.flush();
 
 			if (document.getElementById('login-username')){
 				document.getElementById('login-username').value = username;
@@ -371,7 +363,6 @@
 			event.stopPropagation();
 			loginButtonsSession.resetMessages();
 			Accounts._loginButtonsSession.set('inChangePasswordFlow', false);
-			Meteor.flush();
 		}
 	});
 

--- a/login_buttons_dropdown.js
+++ b/login_buttons_dropdown.js
@@ -12,7 +12,6 @@
 		'click #login-name-link, click #login-sign-in-link': function(event) {
 			event.stopPropagation();
 			loginButtonsSession.set('dropdownVisible', true);
-			Meteor.flush();
 		},
 		'click .login-close': function() {
 			loginButtonsSession.closeDropdown();
@@ -33,7 +32,6 @@
 			event.stopPropagation();
 			loginButtonsSession.resetMessages();
 			loginButtonsSession.set('inChangePasswordFlow', true);
-			Meteor.flush();
 		}
 	});
 


### PR DESCRIPTION
Fix #235.  Some calls to `Meteor.flush()` (in events) seemed unnecessary, while other calls to `Meteor.flush()` were actually needed (to upgrade the web UI according to session variables before trying to modify the contents) and replaced with `Tracker.flush()`.  Now no errors in my app.

I've gone ahead and published [my own fork](https://github.com/edemaine/meteor-accounts-ui-bootstrap-3) which incorporates this PR as well as [@TechplexEngineer's fixes](https://github.com/TechplexEngineer/meteor-accounts-ui-bootstrap-3).  You can use it via `meteor add edemaine:accounts-ui-bootstrap-3`.